### PR TITLE
Add pytest Test Suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@ build/
 dist/
 *.egg-info/
 .idea/
+# Python virtual-environment
+/venv
+# Created by pytest
+.pytest_cache

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ An important note about login function:
 def login(self, email=None, password=None, gsfId=None, authSubToken=None)
 ```
 for first time logins, you should only provide email and password.
-The module will take care of initalizing the api,upload device information 
-to the google account you supplied, and retrieving 
+The module will take care of initalizing the api,upload device information
+to the google account you supplied, and retrieving
 a Google Service Framework ID (which, from now on, will be the android ID of a device).
 
 For the next logins you **should** save the gsfId and the authSubToken, and provide them as parameters to the login function. If you login again with email and password only, this is the equivalent of re-initalizing your android device with a google account.
@@ -26,3 +26,27 @@ For the next logins you **should** save the gsfId and the authSubToken, and prov
 # Documentation
 
 For some documentation about the google play API check out the relative folder.
+
+# Development
+
+If you haven't already, set up a virtual environment in the top-level of the project:
+
+```
+# Create the virtual environment
+python3 -m venv venv
+# Activate the virtual environment
+source venv/bin/activate
+# Install the project's dependencies
+pip install -r requirements.txt
+```
+
+The dependencies installed for development include those described in `setup.py` as well as `pytest`, which is used to run the automated test suite.
+
+To run `pytest`, first export your account `EMAIL` and `PASSWORD`, and also a hex-encoded `GSFID`, as environment variables. Next, run `pytest`.
+
+```
+export EMAIL='XXX'
+export PASSWORD='XXX'
+export GSFID='XXX'
+python -m pytest -v
+```

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+python_files = test_*.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,12 @@
+attrs==17.4.0
+certifi==2018.1.18
+chardet==3.0.4
+idna==2.6
+pluggy==0.6.0
+protobuf==3.5.2
+py==1.5.2
+pycryptodome==3.5.1
+pytest==3.4.2
+requests==2.18.4
+six==1.11.0
+urllib3==1.22

--- a/test/test_googleplay.py
+++ b/test/test_googleplay.py
@@ -1,0 +1,36 @@
+import os
+import unittest
+
+from gpapi.googleplay import GooglePlayAPI
+
+class TestGooglePlay(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.EMAIL = os.environ['EMAIL']
+        cls.PASSWORD = os.environ['PASSWORD']
+        cls.GSFID = int(os.environ['GSFID'], 16)
+        # Next, get AUTHSUBTOKEN. These expire, so it must be regenerated each
+        # time the tests are run.
+        api = GooglePlayAPI(locale='en_US', timezone='EST')
+        c_password = api.encrypt_password(
+            cls.EMAIL, cls.PASSWORD).decode('utf-8')
+        api.getAuthSubToken(cls.EMAIL, c_password)
+        cls.AUTHSUBTOKEN = api.authSubToken
+
+    def setUp(self):
+        # Create a fresh instance of GooglePlayAPI for each test
+        self.API = GooglePlayAPI(locale='en_US', timezone='EST')
+        self.API.login(gsfId=self.GSFID, authSubToken=self.AUTHSUBTOKEN)
+
+    def test_search(self):
+        # Search for 'firefox', requesting just 1 result
+        results = self.API.search('firefox', 1)
+        self.assertTrue(len(results), 1)
+        result = results[0]
+        # Check that the legit Firefox app was found
+        self.assertEqual(result['docId'], 'org.mozilla.firefox')
+        # TODO Add assertions for each of the attributes which the rest of our
+        # code depends on. For now, I think this is the only attribute we
+        # depend on.
+        self.assertIn('versionCode', result)


### PR DESCRIPTION
* Setup instructions
* A test for search()

For https://github.com/NoMore201/googleplay-api/issues/44

Here is an example of the results of running the test suite:
```
(venv) bash-3.2$ python -m pytest -v
================================== test session starts ==================================
platform darwin -- Python 3.5.4, pytest-3.4.2, py-1.5.2, pluggy-0.6.0 -- /Users/pstory/Documents/git_repos/googleplay-api/venv/bin/python
cachedir: .pytest_cache
rootdir: /Users/pstory/Documents/git_repos/googleplay-api, inifile: pytest.ini
collected 1 item                                                                        

test/test_googleplay.py::TestGooglePlay::test_search PASSED                       [100%]

=============================== 1 passed in 4.99 seconds ================================
```

I find unit-testing with pytest to be an invaluable part of the development process, so I think you guys will appreciate using it, too! 