### PR TITLE
FIX broken URL in api.search() that raises an exception when nb_result >20

### DIFF
--- a/gpapi/googleplay.py
+++ b/gpapi/googleplay.py
@@ -350,7 +350,7 @@ class GooglePlayAPI(object):
                 if len(cluster.doc) == 0:
                     break
                 if cluster.doc[0].containerMetadata.nextPageUrl != "":
-                    nextPath = cluster.doc[0].containerMetadata.nextPageUrl
+                    nextPath = FDFE + cluster.doc[0].containerMetadata.nextPageUrl
                 else:
                     nextPath = None
                 apps = []


### PR DESCRIPTION
Hi, 

There is a forgotten `FDFE` when building the URL for the next page of results in `search()`, resulting in failure to search when `nb_result` is superior to 20. 

This patch fixes this issue.