### PR TITLE
Adds much more devices by checking out alldevices branch from play-store-api repo

### DIFF
--- a/scripts/fetch_devices.sh
+++ b/scripts/fetch_devices.sh
@@ -31,7 +31,7 @@ for dev in `ls $RES_DIR | grep properties$`; do
         fi
         echo "==> appending device data for $NAME"
         echo "[$NAME]" >> $DEVS_FILE
-        cat $FILE >> $DEVS_FILE
+        cat $FILE | grep ^[[:alnum:]] | grep '=' >> $DEVS_FILE
         echo "" >> $DEVS_FILE
 done
 

--- a/scripts/fetch_devices.sh
+++ b/scripts/fetch_devices.sh
@@ -20,6 +20,9 @@ git clone --branch $REPO_BRANCH $REPO_SRC $REPO_LOCAL &>/dev/null
 # clean device.properties file
 echo "" > $DEVS_FILE
 
+SAVEIFS=$IFS # store current field separator
+IFS=$(echo -en "\n\b") # set new field separator
+
 for dev in `ls $RES_DIR | grep properties$`; do
         FILE="$RES_DIR/$dev"
         NAME=`echo $dev | sed -e "s/device-\(.*\).properties/\1/"`
@@ -28,6 +31,8 @@ for dev in `ls $RES_DIR | grep properties$`; do
         cat $FILE >> $DEVS_FILE
         echo "" >> $DEVS_FILE
 done
+
+IFS=$SAVEIFS # restore field separator
 
 # cleanup
 echo "==> Cleanup"

--- a/scripts/fetch_devices.sh
+++ b/scripts/fetch_devices.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 REPO_SRC="https://github.com/yeriomin/play-store-api"
-REPO_BRANCH="master"
+REPO_BRANCH="alldevices"
 REPO_LOCAL="/tmp/psapi"
 RES_DIR="${REPO_LOCAL}/src/main/resources"
 

--- a/scripts/fetch_devices.sh
+++ b/scripts/fetch_devices.sh
@@ -20,7 +20,7 @@ git clone --branch $REPO_BRANCH $REPO_SRC $REPO_LOCAL &>/dev/null
 # clean device.properties file
 echo "" > $DEVS_FILE
 
-for dev in `ls $RES_DIR`; do
+for dev in `ls $RES_DIR | grep properties$`; do
         FILE="$RES_DIR/$dev"
         NAME=`echo $dev | sed -e "s/device-\(.*\).properties/\1/"`
         echo "==> appending device data for $NAME"

--- a/scripts/fetch_devices.sh
+++ b/scripts/fetch_devices.sh
@@ -26,6 +26,9 @@ IFS=$(echo -en "\n\b") # set new field separator
 for dev in `ls $RES_DIR | grep properties$`; do
         FILE="$RES_DIR/$dev"
         NAME=`echo $dev | sed -e "s/device-\(.*\).properties/\1/"`
+        if [ -z "$NAME" ]; then
+            continue
+        fi
         echo "==> appending device data for $NAME"
         echo "[$NAME]" >> $DEVS_FILE
         cat $FILE >> $DEVS_FILE

--- a/scripts/fetch_devices.sh
+++ b/scripts/fetch_devices.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 REPO_SRC="https://github.com/yeriomin/play-store-api"
+REPO_BRANCH="master"
 REPO_LOCAL="/tmp/psapi"
 RES_DIR="${REPO_LOCAL}/src/main/resources"
 
@@ -14,7 +15,7 @@ if [ ! -d "./gpapi" ]; then
 fi
 
 echo "==> Cloning play-store-api repo into $REPO_LOCAL"
-git clone $REPO_SRC $REPO_LOCAL &>/dev/null
+git clone --branch $REPO_BRANCH $REPO_SRC $REPO_LOCAL &>/dev/null
 
 # clean device.properties file
 echo "" > $DEVS_FILE


### PR DESCRIPTION
At the time of writing this PR there is an 'alldevices' branch of play-store-api which contains much more devices' properties.
See https://github.com/yeriomin/play-store-api/tree/alldevices/src/main/resources

This PR modifies the fetch_devices.sh script to allow checking out different branch and updates device.properties file.