### PR TITLE
Fix protobuf generation and test file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ class ProtobufBuilder(_build):
         subprocess.run([PROTOC_BIN,
             "--proto_path=" + CURRENT_DIR,
             "--python_out=" + CURRENT_DIR + "/gpapi/",
-            "googleplay.proto"])
+            CURRENT_DIR + "/googleplay.proto"])
         super().run()
 
 setup(name='gpapi',

--- a/test/test.py
+++ b/test/test.py
@@ -18,7 +18,8 @@ print(server.searchSuggest("fir"))
 
 result = server.search("firefox")
 for doc in result:
-    print("doc: {}".format(doc["docid"]))
+    if 'docid' in doc:
+        print("doc: {}".format(doc["docid"]))
     for cluster in doc["child"]:
         print("\tcluster: {}".format(cluster["docid"]))
         for app in cluster["child"]:
@@ -80,7 +81,8 @@ print("\nBrowsing the {} category\n".format(sampleCat))
 browseCat = server.home(cat=sampleCat)
 
 for doc in browseCat:
-    print("doc: {}".format(doc["docid"]))
+    if 'docid' in doc:
+        print("doc: {}".format(doc["docid"]))
     for child in doc["child"]:
         print("\tsubcat: {}".format(child["docid"]))
         for app in child["child"]:


### PR DESCRIPTION
* It seems that new versions of protobuf compiler requires the input
  protobuf file name to have a prefix of the --proto_path, relative
  path does not work in this case
* Fix two null exceptions in test/test.py where docid does not present
  in the query result