### PR TITLE
Fix download of purchased apps

### DIFF
--- a/gpapi/googleplay.py
+++ b/gpapi/googleplay.py
@@ -532,7 +532,8 @@ class GooglePlayAPI(object):
 
         if versionCode is None:
             # pick up latest version
-            versionCode = self.details(packageName).get('versionCode')
+            appDetails = self.details(packageName).get('details').get('appDetails')
+            versionCode = appDetails.get('versionCode')
 
         params = {'ot': str(offerType),
                   'doc': packageName,


### PR DESCRIPTION
This updates delivery() to use the newer protobuf definition in the same way that download() was updated in [46b4271](https://github.com/NoMore201/googleplay-api/commit/46b427124dff0da7efae540a255feb7b5a1ae5ce#diff-00ac717134705ec18cb5b6bfa9397354R623).

Prior to this update, delivery() would fail to retrieve the versionCode, and set it to None. The download URL would then include `vc=None`. It seems that Google was OK with this in the past, delivering the latest version of the app, but currently they return an HTTP "400 Bad Request" error along with the message "Error retrieving information from server. DF-DFERH-01". This update fixes things for me.

(This might be related to #113, though the traceback doesn't match up right....)