### PR TITLE
FIx Header for auth token

### DIFF
--- a/gpapi/googleplay.py
+++ b/gpapi/googleplay.py
@@ -141,7 +141,7 @@ class GooglePlayAPI(object):
         if self.gsfId is not None:
             headers["X-DFE-Device-Id"] = "{0:x}".format(self.gsfId)
         if self.authSubToken is not None:
-            headers["Authorization"] = "GoogleLogin auth=%s" % self.authSubToken
+            headers["Authorization"] = "Bearer %s" % self.authSubToken
         if self.device_config_token is not None:
             headers["X-DFE-Device-Config-Token"] = self.device_config_token
         if self.deviceCheckinConsistencyToken is not None:


### PR DESCRIPTION
The current version of the backend no longer handles the header containing "Authorization
:GoogleLogin auth=ya29.a0AfH6SMBK...". The correct content of the authentication field is "Authorization
:Bearer ya29.a0AfH6SMAP"