### PR TITLE
Fix DisplayUnlockCaptcha error while downloading apps

### DIFF
--- a/gpapi/config.py
+++ b/gpapi/config.py
@@ -141,7 +141,8 @@ class DeviceBuilder(object):
                 "device_country": self.locale[0:2],
                 "lang": self.locale,
                 "client_sig": "38918a453d07199354f8b19af05ec6562ced5788",
-                "callerSig": "38918a453d07199354f8b19af05ec6562ced5788"}
+                "callerSig": "38918a453d07199354f8b19af05ec6562ced5788",
+                "droidguard_results": "dummy123"}
 
     def getAndroidCheckinRequest(self):
         request = googleplay_pb2.AndroidCheckinRequest()


### PR DESCRIPTION
When downloading an app while using an app-specific password with MFA enabled the following error is reported:
`Security check is needed, try to visit https://accounts.google.com/b/0/DisplayUnlockCaptcha to unlock, or setup an app-specific password`

Adding a `droidguard_results` parameter in the login params seems to fix this problem, as suggested by @MrHm in https://github.com/matlink/gplaycli/issues/284#issuecomment-933013877

This PR:
- Fixes https://github.com/NoMore201/googleplay-api/issues/152
- Fixes https://github.com/matlink/gplaycli/issues/284